### PR TITLE
Fix to recover a session

### DIFF
--- a/src/Shared/RedisUtility.cs
+++ b/src/Shared/RedisUtility.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Web.Redis
             }
             catch (Exception ex)
             {
-                LogUtility.LogError("Error GetObjectFromBytes in RedisUtility:", ex.Message, ex.InnerException, ex.StackTrace);
+                LogUtility.LogError("Error GetObjectFromBytes in RedisUtility: {0}", ex.ToString());
                 return null;
             }
         }

--- a/src/Shared/RedisUtility.cs
+++ b/src/Shared/RedisUtility.cs
@@ -75,17 +75,25 @@ namespace Microsoft.Web.Redis
                 return null;
             }
 
-            BinaryFormatter binaryFormatter = new BinaryFormatter();
-            using (MemoryStream memoryStream = new MemoryStream(dataAsBytes, 0, dataAsBytes.Length))
+            try
             {
-                memoryStream.Seek(0, System.IO.SeekOrigin.Begin);
-                object retObject = (object)binaryFormatter.Deserialize(memoryStream);
-
-                if (retObject.GetType() == typeof(RedisNull))
+                BinaryFormatter binaryFormatter = new BinaryFormatter();
+                using (MemoryStream memoryStream = new MemoryStream(dataAsBytes, 0, dataAsBytes.Length))
                 {
-                    return null;
+                    memoryStream.Seek(0, System.IO.SeekOrigin.Begin);
+                    object retObject = (object)binaryFormatter.Deserialize(memoryStream);
+
+                    if (retObject.GetType() == typeof(RedisNull))
+                    {
+                        return null;
+                    }
+                    return retObject;
                 }
-                return retObject;
+            }
+            catch (Exception ex)
+            {
+                LogUtility.LogError("Error GetObjectFromBytes in RedisUtility:", ex.Message, ex.InnerException, ex.StackTrace);
+                return null;
             }
         }
     }


### PR DESCRIPTION
It happens a problem when a login was made and the session was expired using Google Chrome in background, a property of saved session was corrupted and we had problem to recover it. 
Was added an error treatment in GetObjectFromBytes function of RedisUtility class, this error is
saved on project log. See more detailed errors in pictures below:

![error01](https://cloud.githubusercontent.com/assets/3700438/8860333/7b68c72e-3159-11e5-9575-c25a0dd9d03d.png)

![02](https://cloud.githubusercontent.com/assets/3700438/8860343/988a6222-3159-11e5-9190-c24ebe0b0006.png)

