### PR TITLE
Fix issue #2 from Github: Mono: NullReferenceException for concurrent…

### DIFF
--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
@@ -199,6 +199,10 @@ namespace Microsoft.Web.Redis
                 lockAge = TimeSpan.Zero;
                 lockId = 0;
                 actions = SessionStateActions.None;
+                if (id == null)
+                {
+                    return null;
+                }
                 GetAccessToStore(id);
                 ISessionStateItemCollection sessionData = null;
             


### PR DESCRIPTION
We see the same issue described in https://github.com/Azure/aspnet-redis-providers/issues/2. This problem occurs under Mono when the server receives a request without cookies. Mono Session Module does not check the session id for a null before calling GetItem/GetItemExclusive methods of RedisSessionStateProvider.