### PR TITLE
Adding Sentinel and connection string support

### DIFF
--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Web.Redis
 
         public StackExchangeClientConnection(ProviderConfiguration configuration)
         {
-            this._configuration = configuration;
+            _configuration = configuration;
             ConfigurationOptions configOption;
 
             // If connection string is given then use it otherwise use individual options


### PR DESCRIPTION
Utilizing the serviceName property within a connection string, the provider will now discover the master Redis instance and use that IP for it's connection. Support has also been added to use the existing connectionString node of the web.config.