### PR TITLE
Allow the configuration of a Redis key prefix

### DIFF
--- a/src/RedisSessionStateProvider/KeyGenerator.cs
+++ b/src/RedisSessionStateProvider/KeyGenerator.cs
@@ -14,24 +14,25 @@ namespace Microsoft.Web.Redis
         public string LockKey { get; private set; }
         public string InternalKey { get; private set; }
 
-        public KeyGenerator(string id, string applicationName)
+        public KeyGenerator(string id, string applicationName, string prefix)
         {
-            this.id = id;
-            DataKey = "{" + applicationName + "_" + id + "}_Data";
-            LockKey = "{" + applicationName + "_" + id + "}_Write_Lock";
-            InternalKey = "{" + applicationName + "_" + id + "}_Internal";
+            SetKeys(id, applicationName, prefix);
         }
 
-        public void RegenerateKeyStringIfIdModified(string id, string applicationName)
+        public void RegenerateKeyStringIfIdModified(string id, string applicationName, string prefix)
         {
             if (!id.Equals(this.id))
             {
-                this.id = id;
-                DataKey = "{" + applicationName + "_" + id + "}_Data";
-                LockKey = "{" + applicationName + "_" + id + "}_Write_Lock";
-                InternalKey = "{" + applicationName + "_" + id + "}_Internal";
+                SetKeys(id, applicationName, prefix);
             }
         }
 
+        private void SetKeys(string id, string applicationName, string prefix)
+        {
+            this.id = id;
+            DataKey = prefix + "{" + applicationName + "_" + id + "}_Data";
+            LockKey = prefix + "{" + applicationName + "_" + id + "}_Write_Lock";
+            InternalKey = prefix + "{" + applicationName + "_" + id + "}_Internal";
+        }
     }
 }

--- a/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
+++ b/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Web.Redis
         public RedisConnectionWrapper(ProviderConfiguration configuration, string id)
         {
             this.configuration = configuration;
-            Keys = new KeyGenerator(id, configuration.ApplicationName);
+            Keys = new KeyGenerator(id, configuration.ApplicationName, configuration.KeyPrefix);
             
             // Pool is created by server when it starts. don't want to lock everytime when check pool == null.
             // so that is why pool == null exists twice.

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Web.Redis
             }
             else
             {
-                cache.Keys.RegenerateKeyStringIfIdModified(id, configuration.ApplicationName);
+                cache.Keys.RegenerateKeyStringIfIdModified(id, configuration.ApplicationName, configuration.KeyPrefix);
             }
         }
 


### PR DESCRIPTION
Prefixing keys allows users to "namespace" cached data, either by creating a hierarchy with colons or another method of the user's choice. Tools such as Redis Desktop Manager will display namespaced keys in tree, like Windows Explorer shows folder on disk.

For example...
```
KeyPrefix = "MyApp:Sessions:"; // recommended
KeyPrefix = "MyApp-Session-"; // not recommended but acceptable
```