### PR TITLE
Specify initial list size for performance

### DIFF
--- a/src/Shared/RedisUtility.cs
+++ b/src/Shared/RedisUtility.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Web.Redis
 
         public static List<object> GetNewItemsAsList(ChangeTrackingSessionStateItemCollection sessionItems)
         {
-            List<object> list = new List<object>();
+            List<object> list = new List<object>(sessionItems.Keys.Count * 2);
             foreach (string key in sessionItems.Keys)
             {
                 list.Add(key);


### PR DESCRIPTION
Since the count of session keys is known up front, we can save internal
List<T> re-allocations by specifying initial size up front.