### PR TITLE
Added method RedisSessionProvider.UseCustomSerializationBinder(SerializationBinder binder)

### DIFF
--- a/src/RedisSessionStateProvider/Readme.txt
+++ b/src/RedisSessionStateProvider/Readme.txt
@@ -1,4 +1,7 @@
-﻿Microsoft.Web.Redis.RedisSessionStateProvider Nuget package has been added to your project.
+﻿!!!! IMPORTANT !!!!
+This is a forked and modifie version of Microsoft.Web.Redis.RedisSessionStateProvider!
+
+Microsoft.Web.Redis.RedisSessionStateProvider Nuget package has been added to your project.
 
 A new <sessionstate> entry has been added to your web.config. However, any existing session state entries will not have been modified. 
 If you believe you had an existing sessionstate entry, you will need to manually modify the web.config to make the Redis Session State Provider as the default.

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Runtime.Serialization;
 using System.Web;
 using System.Web.SessionState;
 
@@ -408,6 +409,12 @@ namespace Microsoft.Web.Redis
                     throw;
                 }
             }
+        }
+
+        public static void UseCustomSerializationBinder(SerializationBinder binder)
+        {
+            if(binder == null) throw new ArgumentNullException(nameof(binder));
+            RedisUtility.CustomBinder = binder;
         }
     }
 }

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.nuspec
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.nuspec
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
-    <metadata minClientVersion="2.6">
-        <id>Microsoft.Web.RedisSessionStateProvider</id>
-        <version>1.0.0.0</version>
-        <title>RedisSessionStateProvider</title>
-        <authors>Microsoft</authors>
-        <owners>Microsoft</owners>
+    <metadata>
+        <id>Microsoft.Web.RedisSessionStateProvider_CniMod</id>
+        <version>1.6.5.0</version>
+        <title>RedisSessionStateProvider_CniMod</title>
+        <authors>Microsoft,CNI</authors>
+        <owners>Julian Kwieciński</owners>
         <licenseUrl>http://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm</licenseUrl>
         <projectUrl>http://blogs.msdn.com/b/webdev/archive/2014/05/12/announcing-asp-net-session-state-provider-for-redis-preview-release.aspx</projectUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -13,19 +13,19 @@
         <copyright>Microsoft © 2014</copyright>
         <tags>session sessionstateprovider azure microsoft windowsazureofficial redis</tags>
         <dependencies>
-          <dependency id="StackExchange.Redis.StrongName" version="1.0.450" />
+            <dependency id="StackExchange.Redis.StrongName" version="1.0.450" />
         </dependencies>
         <frameworkAssemblies>
-          <frameworkAssembly assemblyName="System" targetFramework="net40" />
-          <frameworkAssembly assemblyName="System.Configuration" targetFramework="net40" />
-          <frameworkAssembly assemblyName="System.Web" targetFramework="net40" />
-          <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework="net40" />
+            <frameworkAssembly assemblyName="System" targetFramework=".NETFramework4.0" />
+            <frameworkAssembly assemblyName="System.Configuration" targetFramework=".NETFramework4.0" />
+            <frameworkAssembly assemblyName="System.Web" targetFramework=".NETFramework4.0" />
+            <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework=".NETFramework4.0" />
         </frameworkAssemblies>
     </metadata>
-  <files>
-    <file src="web.config.transform" target="content\net40\web.config.transform" />
-    <file src="..\..\bin\Release\Signed\v4.0\Microsoft.Web.RedisSessionStateProvider.dll" target="lib\net40\Microsoft.Web.RedisSessionStateProvider.dll" />
-    <file src="..\..\bin\Release\Microsoft.Web.RedisSessionStateProvider\v4.0\Microsoft.Web.RedisSessionStateProvider.pdb" target="lib\net40\Microsoft.Web.RedisSessionStateProvider.pdb" />
-    <file src="Readme.txt" target="Readme.txt" /> 
-  </files>
+    <files>
+        <file src="web.config.transform" target="content\net40\web.config.transform" />
+        <file src="..\..\bin\Release\Microsoft.Web.RedisSessionStateProvider\v4.0\Microsoft.Web.RedisSessionStateProvider.dll" target="lib\net40\Microsoft.Web.RedisSessionStateProvider.dll" />
+        <file src="..\..\bin\Release\Microsoft.Web.RedisSessionStateProvider\v4.0\Microsoft.Web.RedisSessionStateProvider.pdb" target="lib\net40\Microsoft.Web.RedisSessionStateProvider.pdb" />
+        <file src="Readme.txt" target="Readme.txt" />
+    </files>
 </package>

--- a/src/Shared/RedisUtility.cs
+++ b/src/Shared/RedisUtility.cs
@@ -6,12 +6,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 
 namespace Microsoft.Web.Redis
 {
     internal static class RedisUtility
     {
+        internal static SerializationBinder CustomBinder { get; set; }    
+
         public static int AppendRemoveItemsInList(ChangeTrackingSessionStateItemCollection sessionItems, List<object> list)
         {
             int noOfItemsRemoved = 0;
@@ -76,6 +79,10 @@ namespace Microsoft.Web.Redis
             }
 
             BinaryFormatter binaryFormatter = new BinaryFormatter();
+            if (CustomBinder != null)
+            {
+                binaryFormatter.Binder = CustomBinder;
+            }
             using (MemoryStream memoryStream = new MemoryStream(dataAsBytes, 0, dataAsBytes.Length))
             {
                 memoryStream.Seek(0, System.IO.SeekOrigin.Begin);


### PR DESCRIPTION
This is a workaround for ASP.NET Website projects, which are dynamically compiled, therefore their assembly name is changed on every startup.