### PR TITLE
Extensible mechanism to provide different serialization method

### DIFF
--- a/src/OutputCacheProvider/RedisOutputCacheConnectionWrapper.cs
+++ b/src/OutputCacheProvider/RedisOutputCacheConnectionWrapper.cs
@@ -14,11 +14,12 @@ namespace Microsoft.Web.Redis
 
         internal IRedisClientConnection redisConnection;
         ProviderConfiguration configuration;
-        
+        private RedisUtility RedisUtility;
+
         public RedisOutputCacheConnectionWrapper(ProviderConfiguration configuration)
         {
             this.configuration = configuration;
-            
+            this.RedisUtility = new RedisUtility(configuration);
             // Shared connection is created by server when it starts. don't want to lock everytime when check == null.
             // so that is why pool == null exists twice.
             if (sharedConnection == null)

--- a/src/OutputCacheProvider/RedisOutputCacheProvider.csproj
+++ b/src/OutputCacheProvider/RedisOutputCacheProvider.csproj
@@ -68,11 +68,17 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\BinarySerializer.cs">
+      <Link>BinarySerializer.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\ChangeTrackingSessionStateItemCollection.cs">
       <Link>ChangeTrackingSessionStateItemCollection.cs</Link>
     </Compile>
     <Compile Include="..\Shared\IRedisClientConnection.cs">
       <Link>IRedisClientConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\ISerializer.cs">
+      <Link>ISerializer.cs</Link>
     </Compile>
     <Compile Include="..\Shared\LogUtility.cs">
       <Link>LogUtility.cs</Link>

--- a/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
+++ b/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
@@ -18,10 +18,12 @@ namespace Microsoft.Web.Redis
         
         internal IRedisClientConnection redisConnection;
         ProviderConfiguration configuration;
-        
+        private RedisUtility RedisUtility;
+
         public RedisConnectionWrapper(ProviderConfiguration configuration, string id)
         {
             this.configuration = configuration;
+            this.RedisUtility = new RedisUtility(configuration);
             Keys = new KeyGenerator(id, configuration.ApplicationName);
             
             // Pool is created by server when it starts. don't want to lock everytime when check pool == null.

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Web.Redis
                 // Restore action flag from session data
                 if (sessionData["SessionStateActions"] != null) 
                 {
-                    actions = (SessionStateActions)sessionData["SessionStateActions"];
+                    actions = (SessionStateActions)Enum.Parse(typeof(SessionStateActions), sessionData["SessionStateActions"].ToString());
                 }
 
                 //Get data related to this session from sessionDataDictionary and populate session items

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
@@ -68,11 +68,17 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Shared\BinarySerializer.cs">
+      <Link>BinarySerializer.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\ChangeTrackingSessionStateItemCollection.cs">
       <Link>ChangeTrackingSessionStateItemCollection.cs</Link>
     </Compile>
     <Compile Include="..\Shared\IRedisClientConnection.cs">
       <Link>IRedisClientConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\ISerializer.cs">
+      <Link>ISerializer.cs</Link>
     </Compile>
     <Compile Include="..\Shared\LogUtility.cs">
       <Link>LogUtility.cs</Link>

--- a/src/Shared/BinarySerializer.cs
+++ b/src/Shared/BinarySerializer.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace Microsoft.Web.Redis
+{
+    public class BinarySerializer : ISerializer
+    {
+        public byte[] Serialize(object data)
+        {
+            if (data == null)
+            {
+                data = new RedisNull();
+            }
+            var binaryFormatter = new BinaryFormatter();
+            using (var memoryStream = new MemoryStream())
+            {
+                binaryFormatter.Serialize(memoryStream, data);
+                byte[] objectDataAsStream = memoryStream.ToArray();
+                return objectDataAsStream;
+            }
+        }
+
+        public object Deserialize(byte[] data)
+        {
+            if (data == null)
+            {
+                return null;
+            }
+            var binaryFormatter = new BinaryFormatter();
+            using (var memoryStream = new MemoryStream(data, 0, data.Length))
+            {
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                object retObject = (object)binaryFormatter.Deserialize(memoryStream);
+                if (retObject.GetType() == typeof(RedisNull))
+                {
+                    return null;
+                }
+                return retObject;
+            }
+        }
+    }
+}

--- a/src/Shared/ISerializer.cs
+++ b/src/Shared/ISerializer.cs
@@ -1,0 +1,8 @@
+namespace Microsoft.Web.Redis
+{
+    public interface ISerializer
+    {
+        byte[] Serialize(object data);
+        object Deserialize(byte[] data);
+    }
+}

--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Web.Redis
         public int ConnectionTimeoutInMilliSec { get; set; }
         public int OperationTimeoutInMilliSec { get; set; }
         public string ConnectionString { get; set; }
+        public string RedisSerializerType { get; set; }
 
         /* Empty constructor required for testing */
         internal ProviderConfiguration()
@@ -81,7 +82,7 @@ namespace Microsoft.Web.Redis
             Port = GetIntSettings(config, "port", 0);
             AccessKey = GetStringSettings(config, "accessKey", null);
             UseSsl = GetBoolSettings(config, "ssl", true);
-            
+            RedisSerializerType = GetStringSettings(config, "redisSerializerType", null);
             // All below parameters are only fetched from web.config
             DatabaseId = GetIntSettings(config, "databaseId", 0);
             ApplicationName = GetStringSettings(config, "applicationName", null);
@@ -242,7 +243,6 @@ namespace Microsoft.Web.Redis
             }
             return null;
         }
-
 
         // Preference for fetching connection string
         // Either use "settingsClassName" and "settingsMethodName" to provide connectionString

--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -16,10 +16,12 @@ namespace Microsoft.Web.Redis
         ConnectionMultiplexer redisMultiplexer;
         IDatabase connection;
         ProviderConfiguration configuration;
+        private RedisUtility RedisUtility;
 
         public StackExchangeClientConnection(ProviderConfiguration configuration)
         {
             this.configuration = configuration;
+            this.RedisUtility = new RedisUtility(configuration);
             ConfigurationOptions configOption;
 
             // If connection string is given then use it otherwise use individual options
@@ -210,11 +212,6 @@ namespace Microsoft.Web.Redis
         }
 
         public ISessionStateItemCollection GetSessionData(object rowDataFromRedis)
-        {
-            return StackExchangeClientConnection.GetSessionDataStatic(rowDataFromRedis);
-        }
-
-        internal static ISessionStateItemCollection GetSessionDataStatic(object rowDataFromRedis)
         {
             RedisResult rowDataAsRedisResult = (RedisResult)rowDataFromRedis;
             RedisResult[] lockScriptReturnValueArray = (RedisResult[])rowDataAsRedisResult;

--- a/test/OutputCacheProviderUnitTests/RedisOutputCacheUnitTests.cs
+++ b/test/OutputCacheProviderUnitTests/RedisOutputCacheUnitTests.cs
@@ -75,12 +75,15 @@ namespace Microsoft.Web.Redis.UnitTests
             config.Add("port", "1234"); 
             config.Add("accessKey", "hello world");
             config.Add("ssl", "true");
+            config.Add("redisSerializerType", "Microsoft.Web.Redis.BinarySerializer");
             cache.Initialize("name", config);
 
             Assert.Equal(RedisOutputCacheProvider.configuration.Host, "localhost");
             Assert.Equal(RedisOutputCacheProvider.configuration.Port, 1234);
             Assert.Equal(RedisOutputCacheProvider.configuration.AccessKey, "hello world");
             Assert.Equal(RedisOutputCacheProvider.configuration.UseSsl, true);
+            Assert.Equal(RedisOutputCacheProvider.configuration.RedisSerializerType,
+                "Microsoft.Web.Redis.BinarySerializer");
         }
     }
 }

--- a/test/RedisSessionStateProviderFunctionalTests/RedisConnectionWrapperFunctionalTests.cs
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisConnectionWrapperFunctionalTests.cs
@@ -19,8 +19,11 @@ namespace Microsoft.Web.Redis.FunctionalTests
     public class RedisConnectionWrapperFunctionalTests
     {
         static int uniqueSessionNumber = 1;
+        private static RedisUtility RedisUtility = new RedisUtility(Utility.GetDefaultConfigUtility());
+
         private RedisConnectionWrapper GetRedisConnectionWrapperWithUniqueSession()
         {
+            
             return GetRedisConnectionWrapperWithUniqueSession(Utility.GetDefaultConfigUtility());
         }
 

--- a/test/RedisSessionStateProviderUnitTest/RedisConnectionWrapperTests.cs
+++ b/test/RedisSessionStateProviderUnitTest/RedisConnectionWrapperTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Web.Redis.Tests
 {
     public class RedisConnectionWrapperTests
     {
+        private static RedisUtility RedisUtility = new RedisUtility(Utility.GetDefaultConfigUtility());
+
         [Fact]
         public void UpdateExpiryTime_Valid()
         {

--- a/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
+++ b/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
@@ -93,6 +93,7 @@
     <Compile Include="RedisSessionStateProviderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Shared\Utility.cs" />
+    <Compile Include="TestSerializer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/RedisSessionStateProviderUnitTest/TestSerializer.cs
+++ b/test/RedisSessionStateProviderUnitTest/TestSerializer.cs
@@ -1,0 +1,22 @@
+using System.Text;
+
+namespace Microsoft.Web.Redis.Tests
+{
+    public class TestSerializer : ISerializer
+    {
+        internal int SerializeCount;
+        internal int DeserializeCount;
+
+        public object Deserialize(byte[] data)
+        {
+            DeserializeCount++;
+            return Encoding.UTF8.GetString(data);
+        }
+
+        public byte[] Serialize(object data)
+        {
+            SerializeCount++;
+            return Encoding.UTF8.GetBytes(data.ToString());
+        }
+    }
+}

--- a/test/Shared/Utility.cs
+++ b/test/Shared/Utility.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Web.Redis.Tests
             configuration.OperationTimeoutInMilliSec = 1000;
             configuration.RetryTimeout = TimeSpan.Zero;
             configuration.ThrowOnError = true;
+            configuration.RedisSerializerType = null;
             return configuration;
         }
 


### PR DESCRIPTION
An initial implementation for an Extensible mechanism to provide a different serialization method.

To use custom serialization methods, add an Application Setting with key _RedisSerializerType_ containing the type name of a class that implements the interface **Microsoft.Web.Redis.ISerializer**.

For example:

```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <appSettings>
    <add key="RedisSerializerType" value="MyCompany.Redis.JsonSerializer"/>
  </appSettings>
</configuration>

```

An implementation for a JSon serializer using [JSON.NET](http://www.newtonsoft.com/json) could be:
```
namespace MyCompany.Redis
{
    public class JsonSerializer : ISerializer
    {
        private static JsonSerializerSettings _settings = new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All };

        public byte[] Serialize(object data)
        {
            return Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(data, _settings));
        }

        public object Deserialize(byte[] data)
        {
            if (data == null)
            {
                return null;
            }
            return JsonConvert.DeserializeObject(Encoding.UTF8.GetString(data), _settings);
        }
    }
}
```


