### PR TITLE
Redis Cache - updated links to Session State Provider and Output Cach…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains code for Session State and Output Cache providers for R
 
 ## Documentation
 
-See [Azure Redis Session State Provider Documentation](https://msdn.microsoft.com/en-us/library/azure/dn690522.aspx) and [Azure Redis Output Cache Provider Documentation](https://msdn.microsoft.com/en-us/library/azure/dn798898.aspx)
+See [Azure Redis Session State Provider Documentation](https://azure.microsoft.com/documentation/articles/cache-aspnet-session-state-provider/) and [Azure Redis Output Cache Provider Documentation](https://azure.microsoft.com/documentation/articles/cache-aspnet-output-cache-provider/)
 
 ## License
 


### PR DESCRIPTION
…e provider documents on Azure.com. The previous MSDN links forwarded to the right place, but this change fixes the root links in this Readme.