### PR TITLE
Fixed the issue when databaseId from connection string ignored

### DIFF
--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -66,7 +66,8 @@ namespace Microsoft.Web.Redis
             {
                 redisMultiplexer = ConnectionMultiplexer.Connect(configOption, LogUtility.logger);
             }
-            this.connection = redisMultiplexer.GetDatabase(configuration.DatabaseId);
+
+            this.connection = redisMultiplexer.GetDatabase(configOption.DefaultDatabase ?? configuration.DatabaseId);
         }
 
         public IDatabase RealConnection

--- a/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="RedisConnectionWrapperFunctionalTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\Shared\Utility.cs" />
+    <Compile Include="StackExchangeClientConnectionFunctionalTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/RedisSessionStateProviderFunctionalTests/StackExchangeClientConnectionFunctionalTests.cs
+++ b/test/RedisSessionStateProviderFunctionalTests/StackExchangeClientConnectionFunctionalTests.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.Web.Redis.Tests;
+
+using Xunit;
+
+namespace Microsoft.Web.Redis.FunctionalTests
+{
+    public class StackExchangeClientConnectionFunctionalTests
+    {
+        [Fact]
+        public void Constructor_DatabaseIdFromConfigurationProperty()
+        {
+            using (RedisServer redisServer = new RedisServer())
+            {
+                int databaseId = 7;
+                ProviderConfiguration configuration = Utility.GetDefaultConfigUtility();
+                configuration.DatabaseId = databaseId;
+
+                StackExchangeClientConnection connection = new StackExchangeClientConnection(configuration);
+
+                Assert.Equal(databaseId, connection.RealConnection.Database);
+
+                connection.Close();
+            }
+        }
+
+        [Fact]
+        public void Constructor_DatabaseIdFromConnectionString()
+        {
+            using (RedisServer redisServer = new RedisServer())
+            {
+                int databaseId = 3;
+                ProviderConfiguration configuration = Utility.GetDefaultConfigUtility();
+                configuration.ConnectionString = string.Format("localhost, defaultDatabase={0}", databaseId);
+
+                StackExchangeClientConnection connection = new StackExchangeClientConnection(configuration);
+
+                Assert.Equal(databaseId, connection.RealConnection.Database);
+
+                connection.Close();
+            }
+        }
+
+        [Fact]
+        public void Constructor_DatabaseIdFromConfigurationPropertyWhenNotSetInConnectionString()
+        {
+            using (RedisServer redisServer = new RedisServer())
+            {
+                int databaseId = 5;
+                ProviderConfiguration configuration = Utility.GetDefaultConfigUtility();
+                configuration.DatabaseId = databaseId;
+                configuration.ConnectionString = string.Format("localhost");
+
+                StackExchangeClientConnection connection = new StackExchangeClientConnection(configuration);
+
+                Assert.Equal(databaseId, connection.RealConnection.Database);
+
+                connection.Close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
For now there is an issue in configuration when defaultDatabase parameter in connectionString property is ignored always.

This happens because StackExchangeClientConnection uses configuration.DatabaseId without checking parameter in ProviderConfiguration which initializes right.

So in order to do it there is a fix which forses StackExchangeClientConnection to check if databaseId was provided from connection string first.

More about connection string configuration: https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Configuration.md