### PR TITLE
Added ability to provide a certificate for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
--- Added support for client cert authentication for SSL protected Redis endpoints
-
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ASP.NET Redis Providers

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+-- Added support for client cert authentication for SSL protected Redis endpoints
+
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ASP.NET Redis Providers

--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -117,6 +117,8 @@ namespace Microsoft.Web.Redis
                 }
             }
 
+            ClientCertPfxPath = GetStringSettings(config, "clientCertPfxPath", null);
+            ClientCertPfxPassword = GetStringSettings(config, "clientCertPfxPassword", null);
             ConnectionTimeoutInMilliSec = GetIntSettings(config, "connectionTimeoutInMilliseconds", 0);
             OperationTimeoutInMilliSec = GetIntSettings(config, "operationTimeoutInMilliseconds", 0);
         }

--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Web.Redis
         public int OperationTimeoutInMilliSec { get; set; }
         public string ConnectionString { get; set; }
         public string RedisSerializerType { get; set; }
+        public string ClientCertPfxPath { get; set; }
+        public string ClientCertPfxPassword { get; set; }
 
         /* Empty constructor required for testing */
         internal ProviderConfiguration()
@@ -50,8 +52,8 @@ namespace Microsoft.Web.Redis
             SessionStateSection sessionStateSection = (SessionStateSection)WebConfigurationManager.GetSection("system.web/sessionState");
             configuration.SessionTimeout = sessionStateSection.Timeout;
 
-            LogUtility.LogInfo("Host: {0}, Port: {1}, ThrowOnError: {2}, UseSsl: {3}, RetryTimeout: {4}, DatabaseId: {5}, ApplicationName: {6}, RequestTimeout: {7}, SessionTimeout: {8}",
-                                            configuration.Host, configuration.Port, configuration.ThrowOnError, configuration.UseSsl, configuration.RetryTimeout, configuration.DatabaseId, configuration.ApplicationName, configuration.RequestTimeout, configuration.SessionTimeout);
+            LogUtility.LogInfo("Host: {0}, Port: {1}, ThrowOnError: {2}, UseSsl: {3}, RetryTimeout: {4}, DatabaseId: {5}, ApplicationName: {6}, RequestTimeout: {7}, SessionTimeout: {8}, ClientCertPfxPath: {9}, ClientCertPfxPassword: {10}",
+                                            configuration.Host, configuration.Port, configuration.ThrowOnError, configuration.UseSsl, configuration.RetryTimeout, configuration.DatabaseId, configuration.ApplicationName, configuration.RequestTimeout, configuration.SessionTimeout, configuration.ClientCertPfxPath, configuration.ClientCertPfxPassword);
             return configuration;
         }
 

--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
 using System.Web.SessionState;
 using StackExchange.Redis;
 
@@ -56,6 +57,21 @@ namespace Microsoft.Web.Redis
                 if (configuration.OperationTimeoutInMilliSec != 0)
                 {
                     configOption.SyncTimeout = configuration.OperationTimeoutInMilliSec;
+                }
+
+                if (!string.IsNullOrWhiteSpace(configuration.ClientCertPfxPath)
+                    && !string.IsNullOrWhiteSpace(configuration.ClientCertPfxPassword)
+                    && configuration.UseSsl)
+                {
+                    configOption.CertificateSelection += delegate
+                    {
+                        return new X509Certificate2(configuration.ClientCertPfxPath, configuration.ClientCertPfxPassword);
+                    };
+
+                    configOption.CertificateValidation += delegate
+                    {
+                        return true;
+                    };
                 }
             }
             if (LogUtility.logger == null)

--- a/test/Shared/Utility.cs
+++ b/test/Shared/Utility.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Web.Redis.Tests
             configuration.RetryTimeout = TimeSpan.Zero;
             configuration.ThrowOnError = true;
             configuration.RedisSerializerType = null;
+            configuration.ClientCertPfxPath = null;
+            configuration.ClientCertPfxPassword = null;
             return configuration;
         }
 


### PR DESCRIPTION
Exposed functionality in StackExchange.Redis that lets you provide a certificate for authentication.

See https://github.com/StackExchange/StackExchange.Redis/blob/master/StackExchange.Redis/StackExchange/Redis/ConfigurationOptions.cs
