### PR TITLE
Add support for Environment Variables in Connection Strings

### DIFF
--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Web.Redis
             string appSettingsValue = GetFromAppSetting(literalValue);
             if (!string.IsNullOrEmpty(appSettingsValue))
             {
+                appSettingsValue = Environment.ExpandEnvironmentVariables(appSettingsValue);
                 return appSettingsValue;
             }
 
@@ -160,7 +161,10 @@ namespace Microsoft.Web.Redis
                 && ConfigurationManager.ConnectionStrings[literalValue] != null
                 && !string.IsNullOrWhiteSpace(ConfigurationManager.ConnectionStrings[literalValue].ConnectionString))
             {
-                return ConfigurationManager.ConnectionStrings[literalValue].ConnectionString;
+                var connectionString = ConfigurationManager.ConnectionStrings[literalValue].ConnectionString;
+                connectionString = Environment.ExpandEnvironmentVariables(connectionString);
+
+                return connectionString;
             }
             return literalValue;
         }

--- a/test/RedisSessionStateProviderUnitTest/ProviderConfigurationTests.cs
+++ b/test/RedisSessionStateProviderUnitTest/ProviderConfigurationTests.cs
@@ -238,6 +238,22 @@ namespace Microsoft.Web.Redis.Tests
             config.Add(settingsMethodName, "GetSettings");
             Assert.Equal("localhost:6380", ProviderConfiguration.GetConnectionString(config));
         }
+
+        [Fact]
+        public void UseConnectionStringByNameWithEnvironmentVariables()
+        {
+            const string environmentVariableName = "__ASPNET_REDIS_CONNECTION_STRING__";
+            const string expectedConnectionString = "localhost:6380,localhost:6381";
+
+            Environment.SetEnvironmentVariable(environmentVariableName, expectedConnectionString);
+
+            NameValueCollection config = new NameValueCollection();
+            config.Add("connectionString", "RedisSession2");
+            Assert.Equal(expectedConnectionString,
+                ProviderConfiguration.ProviderConfigurationForSessionState(config).ConnectionString);
+
+            Environment.SetEnvironmentVariable(environmentVariableName, null);
+        }
     }
 
     public class Logger

--- a/test/RedisSessionStateProviderUnitTest/app.config
+++ b/test/RedisSessionStateProviderUnitTest/app.config
@@ -2,6 +2,7 @@
 <configuration>
   <connectionStrings>
     <add name="RedisSession" connectionString="localhost:6380"/>
+    <add name="RedisSession2" connectionString="%__ASPNET_REDIS_CONNECTION_STRING__%" />
   </connectionStrings>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
See [The Twelve-Factor App - III. Config](https://www.12factor.net/config).

Connection strings from both `<connectionStrings>` and `<appSettings>` can now use `%ENVIRONMENT_VARIABLE%` references