### PR TITLE
Secure keys

### DIFF
--- a/src/RedisSessionStateProvider/ICacheConnection.cs
+++ b/src/RedisSessionStateProvider/ICacheConnection.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Web.Redis
 {
     internal interface ICacheConnection
     {
-        KeyGenerator Keys { get; set; }
+        IKeyGenerator Keys { get; set; }
         void Set(ISessionStateItemCollection data, int sessionTimeout);
         void UpdateExpiryTime(int timeToExpireInSeconds);
         bool TryTakeWriteLockAndGetData(DateTime lockTime, int lockTimeout, out object lockId, out ISessionStateItemCollection data, out int sessionTimeout);

--- a/src/RedisSessionStateProvider/IKeyGenerator.cs
+++ b/src/RedisSessionStateProvider/IKeyGenerator.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+//
+
+namespace Microsoft.Web.Redis
+{
+    public interface IKeyGenerator
+    {
+        string DataKey { get; }
+        string LockKey { get; }
+        string InternalKey { get; }
+        void GenerateKeys(string id, string applicationName);
+    }
+}

--- a/src/RedisSessionStateProvider/KeyGenerator.cs
+++ b/src/RedisSessionStateProvider/KeyGenerator.cs
@@ -3,44 +3,24 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 //
 
-using System.Security.Cryptography;
-using System.Text;
-
 namespace Microsoft.Web.Redis
 {
-    internal class KeyGenerator
+    internal class SimpleKeyGenerator : IKeyGenerator
     {
-        private static HashAlgorithm Algorithm = SHA256.Create();
         private string id;
         public string DataKey { get; private set; }
         public string LockKey { get; private set; }
         public string InternalKey { get; private set; }
 
-        public KeyGenerator(string id, string applicationName)
+        public void GenerateKeys(string id, string applicationName)
         {
-            Initialize(id, applicationName);
-        }
-
-        public void RegenerateKeyStringIfIdModified(string id, string applicationName)
-        {
-            if (!id.Equals(this.id))
+            if (this.id != id)
             {
-                Initialize(id, applicationName);
+                this.id = id;
+                DataKey = "{" + applicationName + "_" + id + "}_Data";
+                LockKey = "{" + applicationName + "_" + id + "}_Write_Lock";
+                InternalKey = "{" + applicationName + "_" + id + "}_Internal";
             }
         }
-
-        private void Initialize(string id, string applicationName)
-        {
-            this.id = id;
-            DataKey = StringHash("{" + applicationName + "_" + id + "}_Data");
-            LockKey = StringHash("{" + applicationName + "_" + id + "}_Write_Lock");
-            InternalKey = StringHash("{" + applicationName + "_" + id + "}_Internal");
-        }
-
-        private string StringHash(string key)
-        {
-            return Encoding.ASCII.GetString(Algorithm.ComputeHash(Encoding.ASCII.GetBytes(key)));
-        }
-
     }
 }

--- a/src/RedisSessionStateProvider/KeyGenerator.cs
+++ b/src/RedisSessionStateProvider/KeyGenerator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Web.Redis
 {
     internal class KeyGenerator
     {
-        private static SHA256 HashAlgorithm = SHA256.Create();
+        private static HashAlgorithm Algorithm = SHA256.Create();
         private string id;
         public string DataKey { get; private set; }
         public string LockKey { get; private set; }
@@ -39,7 +39,7 @@ namespace Microsoft.Web.Redis
 
         private string StringHash(string key)
         {
-            return Encoding.ASCII.GetString(HashAlgorithm.ComputeHash(Encoding.ASCII.GetBytes(key)));
+            return Encoding.ASCII.GetString(Algorithm.ComputeHash(Encoding.ASCII.GetBytes(key)));
         }
 
     }

--- a/src/RedisSessionStateProvider/KeyGenerator.cs
+++ b/src/RedisSessionStateProvider/KeyGenerator.cs
@@ -3,12 +3,14 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 //
 
-using System;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Microsoft.Web.Redis
 {
     internal class KeyGenerator
     {
+        private static SHA256 HashAlgorithm = SHA256.Create();
         private string id;
         public string DataKey { get; private set; }
         public string LockKey { get; private set; }
@@ -16,21 +18,28 @@ namespace Microsoft.Web.Redis
 
         public KeyGenerator(string id, string applicationName)
         {
-            this.id = id;
-            DataKey = "{" + applicationName + "_" + id + "}_Data";
-            LockKey = "{" + applicationName + "_" + id + "}_Write_Lock";
-            InternalKey = "{" + applicationName + "_" + id + "}_Internal";
+            Initialize(id, applicationName);
         }
 
         public void RegenerateKeyStringIfIdModified(string id, string applicationName)
         {
             if (!id.Equals(this.id))
             {
-                this.id = id;
-                DataKey = "{" + applicationName + "_" + id + "}_Data";
-                LockKey = "{" + applicationName + "_" + id + "}_Write_Lock";
-                InternalKey = "{" + applicationName + "_" + id + "}_Internal";
+                Initialize(id, applicationName);
             }
+        }
+
+        private void Initialize(string id, string applicationName)
+        {
+            this.id = id;
+            DataKey = StringHash("{" + applicationName + "_" + id + "}_Data");
+            LockKey = StringHash("{" + applicationName + "_" + id + "}_Write_Lock");
+            InternalKey = StringHash("{" + applicationName + "_" + id + "}_Internal");
+        }
+
+        private string StringHash(string key)
+        {
+            return Encoding.ASCII.GetString(HashAlgorithm.ComputeHash(Encoding.ASCII.GetBytes(key)));
         }
 
     }

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Web.Redis
             }
             else
             {
-                cache.Keys.RegenerateKeyStringIfIdModified(id, configuration.ApplicationName);
+                cache.Keys.GenerateKeys(id, configuration.ApplicationName);
             }
         }
 

--- a/src/RedisSessionStateProvider/web.config.transform
+++ b/src/RedisSessionStateProvider/web.config.transform
@@ -24,6 +24,7 @@
             loggingClassName = "<Assembly qualified class name that contains logging method specified below>" [String]
             loggingMethodName = "<Logging method should be defined in loggingClass. It should be public, static, does not take any parameters and should have a return type of System.IO.TextWriter.>" [String]
             redisSerializerType = "<Assembly qualified class name that implements Microsoft.Web.Redis.ISerializer>" [String]
+            redisKeyGeneratorType = "<Assembly qualified class name that implements Microsoft.Web.Redis.IKeyGenerator>" [String]
           />
         -->
         <add name="MySessionStateStore" type="Microsoft.Web.Redis.RedisSessionStateProvider"

--- a/src/RedisSessionStateProvider_net462/RedisSessionStateProvider_net462.csproj
+++ b/src/RedisSessionStateProvider_net462/RedisSessionStateProvider_net462.csproj
@@ -139,6 +139,9 @@
     <Compile Include="..\RedisSessionStateProvider\Properties\AssemblyInfo.cs">
       <Link>Properties\AssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="..\RedisSessionStateProvider\IKeyGenerator.cs">
+      <Link>IKeyGenerator.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Web.Redis
         public int OperationTimeoutInMilliSec { get; set; }
         public string ConnectionString { get; set; }
         public string RedisSerializerType { get; set; }
+        public string RedisKeyGeneratorType { get; set; }
 
         /* Empty constructor required for testing */
         internal ProviderConfiguration()
@@ -83,6 +84,7 @@ namespace Microsoft.Web.Redis
             AccessKey = GetStringSettings(config, "accessKey", null);
             UseSsl = GetBoolSettings(config, "ssl", true);
             RedisSerializerType = GetStringSettings(config, "redisSerializerType", null);
+            RedisKeyGeneratorType = GetStringSettings(config, "RedisKeyGeneratorType", null);
             // All below parameters are only fetched from web.config
             DatabaseId = GetIntSettings(config, "databaseId", 0);
             ApplicationName = GetStringSettings(config, "applicationName", null);

--- a/test/RedisSessionStateProviderFunctionalTests/RedisConnectionWrapperFunctionalTests.cs
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisConnectionWrapperFunctionalTests.cs
@@ -79,6 +79,47 @@ namespace Microsoft.Web.Redis.FunctionalTests
         }
 
         [Fact]
+        public void Set_ValidData_WithCustomKeyGenerator()
+        {
+
+            // this also tests host:port config part
+            ProviderConfiguration pc = Utility.GetDefaultConfigUtility();
+            pc.RedisKeyGeneratorType = typeof(TestKeyGenerator).AssemblyQualifiedName;
+            pc.ApplicationName = "APPTEST";
+            pc.Port = 6379;
+            RedisUtility testKeyGeneratorRedisUtility = new RedisUtility(pc);
+
+            using (RedisServer redisServer = new RedisServer())
+            {
+                RedisConnectionWrapper redisConn = GetRedisConnectionWrapperWithUniqueSession(pc);
+
+                // Inserting data into redis server
+                ChangeTrackingSessionStateItemCollection data = new ChangeTrackingSessionStateItemCollection(testKeyGeneratorRedisUtility);
+                data["key"] = "value";
+                data["key1"] = "value1";
+                redisConn.Set(data, 900);
+
+                // Get actual connection and get data blob from redis
+                IDatabase actualConnection = GetRealRedisConnection(redisConn);
+                HashEntry[] sessionDataFromRedis = actualConnection.HashGetAll(redisConn.Keys.DataKey);
+
+                // Check that data should be the same as what was inserted
+                Assert.Equal(2, sessionDataFromRedis.Length);
+                ChangeTrackingSessionStateItemCollection dataFromRedis = new ChangeTrackingSessionStateItemCollection(testKeyGeneratorRedisUtility);
+                foreach (HashEntry entry in sessionDataFromRedis)
+                {
+                    dataFromRedis[entry.Name] = testKeyGeneratorRedisUtility.GetObjectFromBytes(entry.Value).ToString();
+                }
+                Assert.Equal("value", dataFromRedis["key"]);
+                Assert.Equal("value1", dataFromRedis["key1"]);
+
+                // remove data from redis
+                actualConnection.KeyDelete(redisConn.Keys.DataKey);
+                DisposeRedisConnectionWrapper(redisConn);
+            }
+        }
+
+        [Fact]
         public void Set_ValidData()
         {
             // this also tests host:port config part

--- a/test/RedisSessionStateProviderFunctionalTests_462/RedisSessionStateProvider.FunctionalTests_net462.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests_462/RedisSessionStateProvider.FunctionalTests_net462.csproj
@@ -126,6 +126,9 @@
     <Compile Include="..\Shared\TestSerializer.cs">
       <Link>TestSerializer.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\TestKeyGenerator.cs">
+      <Link>TestKeyGenerator.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\Utility.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/RedisSessionStateProviderUnitTest/RedisConnectionWrapperTests.cs
+++ b/test/RedisSessionStateProviderUnitTest/RedisConnectionWrapperTests.cs
@@ -300,5 +300,32 @@ namespace Microsoft.Web.Redis.Tests
                 ))).MustHaveHappened();
         }
 
+        [Fact]
+        public void CustomKeyGenerator_ByAssemblyQualifiedName()
+        {
+            var keyGeneratorTypeName = typeof(TestKeyGenerator).AssemblyQualifiedName;
+            var connectionWrapper = new RedisConnectionWrapper(new ProviderConfiguration() { RedisKeyGeneratorType = keyGeneratorTypeName }, "id");
+            Assert.IsType<TestKeyGenerator>(connectionWrapper.Keys);
+        }
+
+        [Fact]
+        public void CustomKeyGenerator_NotExistingType()
+        {
+            var keyGeneratorTypeName = "This.Type.Does.Not.Exist";
+            Assert.Throws<TypeLoadException>(() =>
+            {
+                new RedisConnectionWrapper(new ProviderConfiguration() { RedisKeyGeneratorType = keyGeneratorTypeName }, "id");
+            });
+        }
+
+        [Fact]
+        public void CustomKeyGenerator_ExistingTypeNotImplementingIKeyGenerator()
+        {
+            var keyGeneratorTypeName = this.GetType().AssemblyQualifiedName;
+            Assert.Throws<InvalidCastException>(() =>
+            {
+                new RedisConnectionWrapper(new ProviderConfiguration() { RedisKeyGeneratorType = keyGeneratorTypeName }, "id");
+            });
+        }
     }
 }

--- a/test/RedisSessionStateProviderUnitTest_462/RedisSessionStateProvider.UnitTest_net462.csproj
+++ b/test/RedisSessionStateProviderUnitTest_462/RedisSessionStateProvider.UnitTest_net462.csproj
@@ -137,6 +137,9 @@
     <Compile Include="..\Shared\TestSerializer.cs">
       <Link>TestSerializer.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\TestKeyGenerator.cs">
+      <Link>TestKeyGenerator.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\Utility.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Shared/TestKeyGenerator.cs
+++ b/test/Shared/TestKeyGenerator.cs
@@ -1,0 +1,31 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+
+namespace Microsoft.Web.Redis.Tests
+{
+    class TestKeyGenerator : IKeyGenerator
+    {
+        private string id;
+        private string applicationName;
+        private static string salt = "totally random salt";
+        public string DataKey { get; private set; }
+        public string LockKey { get; private set; }
+        public string InternalKey { get; private set; }
+
+        public void GenerateKeys(string id, string applicationName)
+        {
+            if(!string.Equals(this.id, id) || !string.Equals(this.applicationName, applicationName)) {
+                this.id = id;
+                this.applicationName = applicationName;
+                DataKey = StringHash("{" + applicationName + "_" + id + "}_Data" + salt);
+                LockKey = StringHash("{" + applicationName + "_" + id + "}_Write_Lock" + salt);
+                InternalKey = StringHash("{" + applicationName + "_" + id + "}_Internal" + salt);
+            }
+        }
+
+        private string StringHash(string s)
+        {
+            return Encoding.ASCII.GetString(SHA512.Create().ComputeHash(Encoding.ASCII.GetBytes(s)));
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #117. This changes the Redis keys to use SHA256 hashed sessionID's instead of just the raw sessionID. This prevents a possible attack where the person managing the Redis instance could see the sessionID's and impersonate a user.