### PR TITLE
Client names

### DIFF
--- a/src/Shared/RedisSharedConnection.cs
+++ b/src/Shared/RedisSharedConnection.cs
@@ -64,10 +64,10 @@ namespace Microsoft.Web.Redis
                     _configOption.SyncTimeout = configuration.OperationTimeoutInMilliSec;
                 }
             }
-
+            var currentClientName = _configOption.ClientName;
             var SERedis = Assembly.GetAssembly(typeof(IRedis)).GetName();
             var providers = Assembly.GetExecutingAssembly().GetName();
-            _configOption.ClientName = $"{_configOption.ClientName}({SERedis.Name}-v{SERedis.Version})({providers.Name}-v{providers.Version})";
+            _configOption.ClientName = $"{currentClientName}({SERedis.Name}-v{SERedis.Version})({providers.Name}-v{providers.Version})";
 
             CreateMultiplexer();
         }

--- a/src/Shared/RedisSharedConnection.cs
+++ b/src/Shared/RedisSharedConnection.cs
@@ -4,6 +4,7 @@
 //
 
 using System;
+using System.Reflection;
 using StackExchange.Redis;
 
 namespace Microsoft.Web.Redis
@@ -63,6 +64,13 @@ namespace Microsoft.Web.Redis
                     _configOption.SyncTimeout = configuration.OperationTimeoutInMilliSec;
                 }
             }
+
+            if (_configOption.ClientName is null)
+            {
+                _configOption.ClientName = "";
+            }
+            _configOption.ClientName += $"{Assembly.GetExecutingAssembly().GetName()}{Assembly.GetExecutingAssembly().GetName().Version}";
+
             CreateMultiplexer();
         }
 

--- a/src/Shared/RedisSharedConnection.cs
+++ b/src/Shared/RedisSharedConnection.cs
@@ -65,11 +65,9 @@ namespace Microsoft.Web.Redis
                 }
             }
 
-            if (_configOption.ClientName is null)
-            {
-                _configOption.ClientName = "";
-            }
-            _configOption.ClientName += $"{Assembly.GetExecutingAssembly().GetName()}{Assembly.GetExecutingAssembly().GetName().Version}";
+            var SERedis = Assembly.GetAssembly(typeof(IRedis)).GetName();
+            var providers = Assembly.GetExecutingAssembly().GetName();
+            _configOption.ClientName = $"{_configOption.ClientName}({SERedis.Name}-v{SERedis.Version})({providers.Name}-v{providers.Version})";
 
             CreateMultiplexer();
         }


### PR DESCRIPTION
Marking connections from the ASP.NET Providers will allow us to measure usage of the new Provider versions by looking at metrics gathered from server logs.

The way to do that is by specifying a ClientName when creating the StackExchange.Redis connection. To see how it works, search for `GetDefaultClientName` in the SE.Redis repo. We'll want the client names to be something like: 

"{default SE.Redis client name, which includes SE.Redis version}{Provider name and version}"
Example: "RoleInstanceName(SE.Redis-v2.5.61)(Microsoft.Web.RedisOutputCacheProvider-v2.2.2)"