### PR TITLE
replace redis-64 with MemuraiDeveloper

### DIFF
--- a/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
+++ b/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="redis-64" Version="3.0.503" />
+    <PackageReference Include="MemuraiDeveloper" Version="2.0.5" />
     <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="redis-64" Version="3.0.503" />
+    <PackageReference Include="MemuraiDeveloper" Version="2.0.5" />
     <PackageReference Include="StackExchange.Redis" Version="2.5.61" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/test/Shared/RedisServer.cs
+++ b/test/Shared/RedisServer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Web.Redis.FunctionalTests
         {
             KillRedisServers();
             _server = new Process();
-            string executable_path = $"{Environment.CurrentDirectory}\\..\\..\\..\\..\\..\\packages\\redis-64\\3.0.503\\tools\\redis-server.exe";
+            string executable_path = $"{Environment.CurrentDirectory}\\..\\..\\..\\..\\..\\packages\\memuraideveloper\\2.0.5\\tools\\memurai.exe";
             _server.StartInfo.FileName = executable_path;
             _server.StartInfo.Arguments = "--maxmemory 20000000";
             _server.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;


### PR DESCRIPTION
Use MemuraiDeveloper as a drop-in replacement for redis-64 because the latter is no longer supported