### PR TITLE
Embed Provider identities in connection ClientNames

### DIFF
--- a/src/Shared/RedisSharedConnection.cs
+++ b/src/Shared/RedisSharedConnection.cs
@@ -73,7 +73,10 @@ namespace Microsoft.Web.Redis
         private static void EmbedProviderIdentityInConnectionClientName(ConfigurationOptions options)
         {
             AssemblyName provider = Assembly.GetExecutingAssembly().GetName();
-            options.ClientName += $"{options.Defaults.ClientName}({provider.Name}-v{provider.Version})";
+            if (String.IsNullOrWhiteSpace(options.ClientName))
+            {
+                options.ClientName = $"{options.Defaults.ClientName}({provider.Name}-v{provider.Version})";
+            }
         }
 
         public IDatabase Connection

--- a/src/Shared/RedisSharedConnection.cs
+++ b/src/Shared/RedisSharedConnection.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Web.Redis
 
             CreateMultiplexer();
         }
-        
+
         public IDatabase Connection
         {
             get { return _redisMultiplexer.Value.GetDatabase(_configOption.DefaultDatabase ?? _configuration.DatabaseId); }
@@ -92,7 +92,7 @@ namespace Microsoft.Web.Redis
                 {
                     var utcNow = DateTimeOffset.UtcNow;
                     elapsedSinceLastReconnect = utcNow - lastReconnectTime;
-
+                    
                     if (elapsedSinceLastReconnect < ReconnectFrequency)
                     {
                         return; // Some other thread made it through the check and the lock, so nothing to do. 


### PR DESCRIPTION
Marking connections from the ASP.NET Providers will allow us to measure usage of the new Provider versions by looking at metrics gathered from server logs.

The way to do that is by specifying a ClientName when creating the StackExchange.Redis connection. To see how it works, search for `GetDefaultClientName` in the SE.Redis repo. We'll want the client names to be something like: 

"{default SE.Redis client name, which includes SE.Redis version}{Provider name and version}"
Example: "RoleInstanceName(SE.Redis-v2.5.61)(Microsoft.Web.RedisOutputCacheProvider-v2.2.2)"