### PR TITLE
Upgrade SE Redis from 2.6.70 to 2.6.96

### DIFF
--- a/src/OutputCacheProvider/RedisOutputCacheProvider.csproj
+++ b/src/OutputCacheProvider/RedisOutputCacheProvider.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/src/RedisOutputCachingMiddleware/RedisOutputCachingMiddleware.csproj
+++ b/src/RedisOutputCachingMiddleware/RedisOutputCachingMiddleware.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.16" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
   </ItemGroup>
 
 </Project>

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />

--- a/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
+++ b/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />

--- a/test/OutputCacheProviderUnitTests/RedisOutputCacheProvider.UnitTests.csproj
+++ b/test/OutputCacheProviderUnitTests/RedisOutputCacheProvider.UnitTests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />

--- a/test/RedisOutputCachingMiddleWareFunctionalTests/RedisOutputCachingMiddleWare.FunctionalTests.csproj
+++ b/test/RedisOutputCachingMiddleWareFunctionalTests/RedisOutputCachingMiddleWare.FunctionalTests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.4" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />

--- a/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
+++ b/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />


### PR DESCRIPTION
A serious deadlock bug was recently found and fixed in the StackExchange.Redis client library. The bug can prevent client applications from recovering their Redis connection after transient errors (like those seen during server maintenance). 

Issue: https://github.com/StackExchange/StackExchange.Redis/issues/2376
PR: https://github.com/StackExchange/StackExchange.Redis/pull/2378

We should update the package version referenced by our ASP.NET Provider packages to use SE.Redis version 2.6.96 or greater, so customers aren't vulnerable to the deadlock.