### PR TITLE
Fix for TLS1.1 and 1.2 connections

### DIFF
--- a/src/Shared/RedisSharedConnection.cs
+++ b/src/Shared/RedisSharedConnection.cs
@@ -6,6 +6,7 @@
 using System;
 using StackExchange.Redis;
 using System.Reflection;
+using System.Security.Authentication;
 
 namespace Microsoft.Web.Redis
 {
@@ -52,6 +53,7 @@ namespace Microsoft.Web.Redis
                 }
                 _configOption.Password = configuration.AccessKey;
                 _configOption.Ssl = configuration.UseSsl;
+                _configOption.SslProtocols = SslProtocols.Ssl3 | SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
                 _configOption.AbortOnConnectFail = false;
 
                 if (configuration.ConnectionTimeoutInMilliSec != 0)


### PR DESCRIPTION
Added support to RedisSessionStateProvider to allow connections to TLS 1.1 and 1.2 when those minimums are set.

This will allow users to continue to use RedisSessionStateProvider when Azure removes support for 1.0 and 1.1 (Date TBD)

https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-remove-tls-10-11