### PR TITLE
Remove trycatch from serialization methods

### DIFF
--- a/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
+++ b/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
@@ -123,18 +123,11 @@ namespace Microsoft.Web.Redis
 
         private byte[] SerializeSessionStateItemCollection(ISessionStateItemCollection sessionStateItemCollection)
         {
-            try
-            {
-                MemoryStream ms = new MemoryStream();
-                BinaryWriter writer = new BinaryWriter(ms);
-                ((SessionStateItemCollection)sessionStateItemCollection).Serialize(writer);
-                writer.Close();
-                return ms.ToArray();
-            }
-            catch
-            {
-                return null;
-            }
+            MemoryStream ms = new MemoryStream();
+            BinaryWriter writer = new BinaryWriter(ms);
+            ((SessionStateItemCollection)sessionStateItemCollection).Serialize(writer);
+            writer.Close();
+            return ms.ToArray();
         }
 
         public void Set(ISessionStateItemCollection data, int sessionTimeout)

--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -186,16 +186,9 @@ namespace Microsoft.Web.Redis
 
         private SessionStateItemCollection DeserializeSessionStateItemCollection(RedisResult serializedSessionStateItemCollection)
         {
-            try
-            {
-                MemoryStream ms = new MemoryStream((byte[])serializedSessionStateItemCollection);
-                BinaryReader reader = new BinaryReader(ms);
-                return SessionStateItemCollection.Deserialize(reader);
-            }
-            catch
-            {
-                return null;
-            }
+            MemoryStream ms = new MemoryStream((byte[])serializedSessionStateItemCollection);
+            BinaryReader reader = new BinaryReader(ms);
+            return SessionStateItemCollection.Deserialize(reader);
         }
 
         public void Set(string key, byte[] data, DateTime utcExpiry)


### PR DESCRIPTION
In response to issue #190 
Serialization methods should throw an exception instead of returning null. 