### PR TITLE
Bump SessionStateModule version from 1.1.0 to 2.0.0

### DIFF
--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
@@ -22,7 +22,7 @@
     <Compile Include="..\Shared\*" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />

--- a/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />

--- a/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
+++ b/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
-    <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />


### PR DESCRIPTION
Use current version of **Microsoft.AspNet.SessionState.SessionStateModule** to utilize `skipKeepAliveWhenUnused` setting to skip updating the session item expiry for requests that have session disabled.

re: issue https://github.com/Azure/aspnet-redis-providers/issues/198