### PR TITLE
Downgrade Microsoft.Bcl.AsyncInterfaces version 

### DIFF
--- a/src/OutputCacheProvider/Properties/AssemblyInfo.cs
+++ b/src/OutputCacheProvider/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 #if !NOCOMMONASSEMBLYVERSION
-[assembly: AssemblyVersion("4.1.0.0")]
-[assembly: AssemblyFileVersion("4.1.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 #endif
 [assembly: AssemblyTitle("Cache Providers")]

--- a/src/OutputCacheProvider/RedisOutputCacheProvider.csproj
+++ b/src/OutputCacheProvider/RedisOutputCacheProvider.csproj
@@ -8,7 +8,7 @@
     <SignAssembly Condition=" '$(EnableCodeSigning)' == 'true' ">true</SignAssembly>
     <DelaySign Condition=" '$(EnableCodeSigning)' == 'true' ">true</DelaySign>
     <AssemblyOriginatorKeyFile Condition=" '$(EnableCodeSigning)' == 'true' ">dummy.snk</AssemblyOriginatorKeyFile>
-	<VersionPrefix>4.0.0</VersionPrefix>
+	<VersionPrefix>4.0.1</VersionPrefix>
 	<authors>Microsoft</authors>
 	<copyright>© Microsoft Corporation. All rights reserved.</copyright>
 	<PackageLicenseUrl>https://webpifeed.blob.core.windows.net/webpifeed/eula/net_library_eula_enu.htm</PackageLicenseUrl>
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/src/RedisSessionStateProvider/Properties/AssemblyInfo.cs
+++ b/src/RedisSessionStateProvider/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 #if !NOCOMMONASSEMBLYVERSION
-[assembly: AssemblyVersion("5.1.0.0")]
-[assembly: AssemblyFileVersion("5.1.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 #endif
 [assembly: AssemblyTitle("Cache Providers")]

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.csproj
@@ -8,7 +8,7 @@
     <SignAssembly Condition=" '$(EnableCodeSigning)' == 'true' ">true</SignAssembly>
     <DelaySign Condition=" '$(EnableCodeSigning)' == 'true' ">true</DelaySign>
     <AssemblyOriginatorKeyFile Condition=" '$(EnableCodeSigning)' == 'true' ">dummy.snk</AssemblyOriginatorKeyFile>
-	<VersionPrefix>5.0.0</VersionPrefix>
+	<VersionPrefix>5.0.1</VersionPrefix>
 	  <authors>Microsoft</authors>
 	<copyright>© Microsoft Corporation. All rights reserved.</copyright>
 	<PackageLicenseUrl>https://webpifeed.blob.core.windows.net/webpifeed/eula/net_library_eula_enu.htm</PackageLicenseUrl>
@@ -23,7 +23,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />

--- a/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
+++ b/test/OutputCacheProviderFunctionalTests/RedisOutputCacheProvider.FunctionalTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/test/OutputCacheProviderUnitTests/RedisOutputCacheProvider.UnitTests.csproj
+++ b/test/OutputCacheProviderUnitTests/RedisOutputCacheProvider.UnitTests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNet.OutputCache.OutputCacheModuleAsync" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/test/OutputCacheProviderUnitTests/app.config
+++ b/test/OutputCacheProviderUnitTests/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
+++ b/test/RedisSessionStateProviderFunctionalTests/RedisSessionStateProvider.FunctionalTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />

--- a/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
+++ b/test/RedisSessionStateProviderUnitTest/RedisSessionStateProvider.UnitTest.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNet.SessionState.SessionStateModule" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />


### PR DESCRIPTION
This aims to address issue [#184](https://github.com/Azure/aspnet-redis-providers/pull/201)