### PR TITLE
Add TryCatch block back to SessionState provider

### DIFF
--- a/src/Shared/StackExchangeClientConnection.cs
+++ b/src/Shared/StackExchangeClientConnection.cs
@@ -186,13 +186,16 @@ namespace Microsoft.Web.Redis
 
         internal SessionStateItemCollection DeserializeSessionStateItemCollection(RedisResult serializedSessionStateItemCollection)
         {
-            if (serializedSessionStateItemCollection is null)
+            try
+            {
+                MemoryStream ms = new MemoryStream((byte[])serializedSessionStateItemCollection);
+                BinaryReader reader = new BinaryReader(ms);
+                return SessionStateItemCollection.Deserialize(reader);
+            }
+            catch
             {
                 return null;
             }
-            MemoryStream ms = new MemoryStream((byte[])serializedSessionStateItemCollection);
-            BinaryReader reader = new BinaryReader(ms);
-            return SessionStateItemCollection.Deserialize(reader);
         }
 
         public void Set(string key, byte[] data, DateTime utcExpiry)


### PR DESCRIPTION
Users are still having issues where the buffer is null. We removed the TryCatch for serialization and deserialization to avoid swallowing a "not serializable" exception. Hence we are only adding the try-catch back to the deserialization method 