### PR TITLE
removing empty catch.

### DIFF
--- a/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
+++ b/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
@@ -334,16 +334,10 @@ namespace Microsoft.Web.Redis
                 List<object> list = new List<object>();
                 int noOfItemsRemoved = 0;
                 int noOfItemsUpdated = 0;
-                try
-                {
-                    byte[] serializedSessionStateItemCollection = SerializeSessionStateItemCollection(data);
-                    list.Add("SessionState");
-                    list.Add(serializedSessionStateItemCollection);
-                    noOfItemsUpdated = 1;
-                }
-                catch
-                {
-                }
+                byte[] serializedSessionStateItemCollection = SerializeSessionStateItemCollection(data);
+                list.Add("SessionState");
+                list.Add(serializedSessionStateItemCollection);
+                noOfItemsUpdated = 1;
 
                 keyArgs = new string[] { Keys.LockKey, Keys.DataKey, Keys.InternalKey };
                 valueArgs = new object[list.Count + 8]; // this +8 is for first wight values in ARGV that we will add now


### PR DESCRIPTION
Fixes #216 - Just pulls out the catch and adds a test to make sure the error you'd expect to be thrown is thrown.