### PR TITLE
FEATURE: add EnableSessionKeyHashtag config to allow custom key strategies

### DIFF
--- a/src/RedisSessionStateProvider/KeyGenerator.cs
+++ b/src/RedisSessionStateProvider/KeyGenerator.cs
@@ -14,24 +14,25 @@ namespace Microsoft.Web.Redis
         public string LockKey { get; private set; }
         public string InternalKey { get; private set; }
 
-        private void GenerateKeys(string id, string app)
+        private void GenerateKeys(string id, string app, bool enableSessionKeyHashtag)
         {
             this.id = id;
-            DataKey = $"{{{app}_{id}}}_SessionStateItemCollection";
-            LockKey = $"{{{app}_{id}}}_WriteLock";
-            InternalKey = $"{{{app}_{id}}}_SessionTimeout";
+            string prefixKey = enableSessionKeyHashtag ?  $"{{{app}_{id}}}" : $"{app}_{id}";
+            DataKey = $"{prefixKey}_SessionStateItemCollection";
+            LockKey = $"{prefixKey}_WriteLock";
+            InternalKey = $"{prefixKey}_SessionTimeout";
         }
 
-        public KeyGenerator(string sessionId, string applicationName)
+        public KeyGenerator(string sessionId, string applicationName, bool enableSessionKeyHashtag)
         {
-            GenerateKeys(sessionId, applicationName);
+            GenerateKeys(sessionId, applicationName,enableSessionKeyHashtag);
         }
 
-        public void RegenerateKeyStringIfIdModified(string sessionId, string applicationName)
+        public void RegenerateKeyStringIfIdModified(string sessionId, string applicationName, bool enableSessionKeyHashtag)
         {
             if (!sessionId.Equals(this.id))
             {
-                GenerateKeys(sessionId, applicationName);
+                GenerateKeys(sessionId, applicationName, enableSessionKeyHashtag);
             }
         }
     }

--- a/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
+++ b/src/RedisSessionStateProvider/RedisConnectionWrapper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Web.Redis
         public RedisConnectionWrapper(ProviderConfiguration configuration, string id)
         {
             this.configuration = configuration;
-            Keys = new KeyGenerator(id, configuration.ApplicationName);
+            Keys = new KeyGenerator(id, configuration.ApplicationName,configuration.EnableSessionKeyHashtag);
 
             // only single object of RedisSharedConnection will be created and then reused
             if (sharedConnection == null)

--- a/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
+++ b/src/RedisSessionStateProvider/RedisSessionStateProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Web.Redis
             }
             else
             {
-                cache.Keys.RegenerateKeyStringIfIdModified(id, configuration.ApplicationName);
+                cache.Keys.RegenerateKeyStringIfIdModified(id, configuration.ApplicationName, configuration.EnableSessionKeyHashtag);
             }
         }
 

--- a/src/Shared/ProviderConfiguration.cs
+++ b/src/Shared/ProviderConfiguration.cs
@@ -14,7 +14,7 @@ using System.Web.Hosting;
 namespace Microsoft.Web.Redis
 {
     internal class ProviderConfiguration
-    {
+    {    
         public TimeSpan RequestTimeout { get; set; }
         public TimeSpan SessionTimeout { get; set; }
         public int Port { get; set; }
@@ -28,7 +28,7 @@ namespace Microsoft.Web.Redis
         public int ConnectionTimeoutInMilliSec { get; set; }
         public int OperationTimeoutInMilliSec { get; set; }
         public string ConnectionString { get; set; }
-
+        public bool EnableSessionKeyHashtag { get; set; } = true;
         /* Empty constructor required for testing */
 
         internal ProviderConfiguration()
@@ -84,6 +84,7 @@ namespace Microsoft.Web.Redis
             Port = GetIntSettings(config, "port", 0);
             AccessKey = GetStringSettings(config, "accessKey", null);
             UseSsl = GetBoolSettings(config, "ssl", true);
+            EnableSessionKeyHashtag = GetBoolSettings(config, "enableSessionKeyHashtag", true);
             // All below parameters are only fetched from web.config
             DatabaseId = GetIntSettings(config, "databaseId", 0);
             ApplicationName = GetStringSettings(config, "applicationName", null);


### PR DESCRIPTION
This change allows users to opt-out of the default Redis Cluster key hashing pattern ({app_id}).

By setting enableSessionKeyHashtag to false, users can define their own custom sharding strategies (e.g.  app_{id}) directly via the applicationName configuration or custom session ID managers, without being forced into the default wrapper.